### PR TITLE
disabled Digital Salmon from side bar

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -41,8 +41,8 @@ subitems:
           url: /fairdom-in-use/covid19dm
         - title: Centre for Digital Life
           url: /fairdom-in-use/digitallifenorway
-        - title: Digital Salmon
-          url: /fairdom-in-use/digitallifenorway
+#        - title: Digital Salmon
+#          url: /fairdom-in-use/digitallifenorway
         - title: Leipzig Health Atlas
           url: /fairdom-in-use/leipzig
         - title: LiSyM


### PR DESCRIPTION
it points to the same place as Centre for Digital Life, which I selected to kjeep as it matches the page title