### PR TITLE
Add FAIRDOM acronym in full to About page

### DIFF
--- a/pages/about/about.md
+++ b/pages/about/about.md
@@ -15,5 +15,7 @@ redirect_from:
 
 The associate partners work together in varying degrees from using the software and providing development feedback, through to co-development of software, knowledge and broader collaboration.   
 
+('FAIRDOM' stands for Findable, Accessible, Interoperable and Reusable Documents, Operations and Models.)
+
 {% include image.html file="About_FAIRDOM.png" alt="FAIRDOM About" class="screenshot" click=true %}
 


### PR DESCRIPTION
Added a sentence after the other text to clearly explain what the DOM letters stand for. I could not find a way to work it into the earlier sentences, they are so neatly crafted that I would be spoiling them, they would no longer flow well.

(If there are any other changes I would like you to review, I'll put them in a batch together next week. This one might require some more careful thought and consultation.)