### PR TITLE
Pages for FAIRDOM Mini Hackathon 2025

### DIFF
--- a/_events/2025-02-20-FAIRDOM-mini-hackathon-online.md
+++ b/_events/2025-02-20-FAIRDOM-mini-hackathon-online.md
@@ -1,0 +1,32 @@
+---
+title: FAIRDOM Mini Hackathon Online
+start_date: 2025-02-20
+location: online
+---
+
+We would like to invite you to our upcoming event. In a change to our usual FAIRDOM User Meeting format, we have decided to host the first FAIRDOM Mini Hackathon Online. Users, developers, leaders and advocates will have an opportunity to collaborate, discuss and progress a range of matters and features which will be of benefit to the wider FAIRDOM-SEEK community. We also welcome anybody interested in learning more about FAIRDOM-SEEK and how it could benefit their work.
+
+## Details
+
+- **Date**: Thursday, 20 February 2025
+- **Location**: Online (Zoom link to be shared upon registration)
+- **Start**: [8am Eastern, 13:00 GMT, 14:00 CET](https://www.timeanddate.com/worldclock/converter.html?iso=20250220T130000&p1=tz_gmt&p2=tz_cet&p3=tz_et)
+- **End**: [1pm Eastern, 18:00 GMT, 19:00 CET](https://www.timeanddate.com/worldclock/converter.html?iso=20250220T180000&p1=tz_gmt&p2=tz_cet&p3=tz_et)
+- You are welcome to join late or leave early. Full agenda to be announced.
+
+## Topics
+
+You will be able to select from a list of topics or suggest your own. The topics relate to bug finding, search, user interface, metadata and machine learning.
+
+- Making additional discoveries from existing data, using **machine learning** tools
+- Improving user interface features for **multi-select search** and/or ISA/file navigation
+- Collecting and organizing ‘**niggles**’
+- Identifying places where weighted **auto-complete feature** could be implemented
+- Improving **controlled vocabulary** usage and extended metadata
+
+## Register now
+
+Please complete the free registration link below by Friday, 24 January 2025 and share with your colleagues.
+- [Register for the FAIRDOM Mini Hackathon Online](https://bit.ly/fdhack25) 
+
+If you have any questions, please [contact us](/contact).

--- a/_events/2025-02-20-FAIRDOM-mini-hackathon-online.md
+++ b/_events/2025-02-20-FAIRDOM-mini-hackathon-online.md
@@ -16,13 +16,16 @@ We would like to invite you to our upcoming event. In a change to our usual FAIR
 
 ## Topics
 
-You will be able to select from a list of topics or suggest your own. The topics relate to bug finding, search, user interface, metadata and machine learning.
+You will be able to select from a list of topics or suggest your own. The topics relate to RO-Crates, bug finding, search, user interface, metadata and machine learning.
+
+Topic titles (subject to change):
 
 - Making additional discoveries from existing data, using **machine learning** tools
 - Improving user interface features for **multi-select search** and/or ISA/file navigation
 - Collecting and organizing ‘**niggles**’
 - Identifying places where weighted **auto-complete feature** could be implemented
 - Improving **controlled vocabulary** usage and extended metadata
+- **RO-Crates** for importing into FAIRDOM-SEEK
 
 ## Register now
 

--- a/_news/2024-10-31-registration-open-first-fairdom-mini-hackathon.md
+++ b/_news/2024-10-31-registration-open-first-fairdom-mini-hackathon.md
@@ -5,6 +5,6 @@ title: "Registration now open for the first FAIRDOM Mini Hackathon"
 In a change to our usual FAIRDOM User Meeting format, we have decided to host the first FAIRDOM Mini Hackathon Online. Users, developers, leaders and advocates will have an opportunity to collaborate, discuss and progress a range of matters and features which will be of benefit to the wider FAIRDOM-SEEK community. We also welcome anybody interested in learning more about FAIRDOM-SEEK and how it could benefit their work.
 
 The event will run on Zoom on **Thursday, 20 February 2025** for 5 hours, providing opportunities for people in eastern North America, western/central Europe and western/central Africa to work together. 
-You will be able to select from a list of topics or suggest your own. The topics relate to bug finding, search, user interface, metadata and machine learning.
+You will be able to select from a list of topics or suggest your own. The topics relate to RO-Crates, bug finding, search, user interface, metadata and machine learning.
 
 For full details and to register, please visit the [FAIRDOM Mini Hackathon 2025 event page](/events/2025-02-20-FAIRDOM-mini-hackathon-online).

--- a/_news/2024-10-31-registration-open-first-fairdom-mini-hackathon.md
+++ b/_news/2024-10-31-registration-open-first-fairdom-mini-hackathon.md
@@ -1,0 +1,10 @@
+---
+title: "Registration now open for the first FAIRDOM Mini Hackathon"
+---
+
+In a change to our usual FAIRDOM User Meeting format, we have decided to host the first FAIRDOM Mini Hackathon Online. Users, developers, leaders and advocates will have an opportunity to collaborate, discuss and progress a range of matters and features which will be of benefit to the wider FAIRDOM-SEEK community. We also welcome anybody interested in learning more about FAIRDOM-SEEK and how it could benefit their work.
+
+The event will run on Zoom on **Thursday, 20 February 2025** for 5 hours, providing opportunities for people in eastern North America, western/central Europe and western/central Africa to work together. 
+You will be able to select from a list of topics or suggest your own. The topics relate to bug finding, search, user interface, metadata and machine learning.
+
+For full details and to register, please visit the [FAIRDOM Mini Hackathon 2025 event page](/events/2025-02-20-FAIRDOM-mini-hackathon-online).


### PR DESCRIPTION
Added an event page with link to the registration form and invitation message.

Added a news pages with link to the event page and summary. The news page will also appear in FAIRDOMHub.

Since the format is not the same as User Meetings, I think a News page is warranted. 